### PR TITLE
Remove nested absolute deprecation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,9 @@
 ## [HEAD] \(v2.2.0\)
 > Unreleased
 
-- **Deprecation:** Deprecate nested routes with absolute paths ([6f40116])
 - **Bugfix:** Stop matching extraneous slashes in paths ([#3158])
 
 [HEAD]: https://github.com/taion/rrtr/compare/v2.1.2...HEAD
-[6f40116]: https://github.com/taion/rrtr/commit/6f401169415da3e5b34eb93beb846468a0a369b2
 [#3158]: https://github.com/reactjs/react-router/pull/3158
 
 

--- a/modules/__tests__/isActive-test.js
+++ b/modules/__tests__/isActive-test.js
@@ -6,7 +6,6 @@ import IndexRoute from '../IndexRoute'
 import Router from '../Router'
 import Route from '../Route'
 import qs from 'qs'
-import shouldWarn from './shouldWarn'
 
 describe('isActive', function () {
 
@@ -190,10 +189,6 @@ describe('isActive', function () {
   })
 
   describe('a pathname that matches a parent route, but not the URL directly', function () {
-    beforeEach(() => {
-      shouldWarn('deprecated')
-    })
-
     describe('with no query', function () {
       it('is active', function (done) {
         render((
@@ -256,10 +251,6 @@ describe('isActive', function () {
   })
 
   describe('a pathname that matches a nested absolute path', function () {
-    beforeEach(() => {
-      shouldWarn('deprecated')
-    })
-
     describe('with no query', function () {
       it('is active', function (done) {
         render((

--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -11,7 +11,8 @@ describe('matchRoutes', function () {
   let routes
   let
     RootRoute, UsersRoute, UsersIndexRoute, UserRoute, PostRoute, FilesRoute,
-    AboutRoute, GreedyRoute, OptionalRoute, OptionalRouteChild, CatchAllRoute
+    AboutRoute, TeamRoute, ProfileRoute, GreedyRoute, OptionalRoute,
+    OptionalRouteChild, CatchAllRoute
   let createLocation = createMemoryHistory().createLocation
 
   beforeEach(function () {
@@ -19,7 +20,10 @@ describe('matchRoutes', function () {
     <Route>
       <Route path="users">
         <IndexRoute />
-        <Route path=":userID" />
+        <Route path=":userID">
+          <Route path="/profile" />
+        </Route>
+        <Route path="/team" />
       </Route>
     </Route>
     <Route path="/about" />
@@ -38,10 +42,16 @@ describe('matchRoutes', function () {
               UserRoute = {
                 path: ':userID',
                 childRoutes: [
+                  ProfileRoute = {
+                    path: '/profile'
+                  },
                   PostRoute = {
                     path: ':postID'
                   }
                 ]
+              },
+              TeamRoute = {
+                path: '/team'
               }
             ]
           }
@@ -224,13 +234,6 @@ describe('matchRoutes', function () {
 
     describe('when the location matches a nested absolute route', function () {
       it('matches the correct routes', function (done) {
-        shouldWarn('deprecated')
-
-        const TeamRoute = {
-          path: '/team'
-        }
-        UsersRoute.childRoutes.push(TeamRoute)
-
         matchRoutes(routes, createLocation('/team'), function (error, match) {
           expect(match).toExist()
           expect(match.routes).toEqual([ RootRoute, UsersRoute, TeamRoute ])
@@ -241,13 +244,6 @@ describe('matchRoutes', function () {
 
     describe('when the location matches an absolute route nested under a route with params', function () {
       it('matches the correct routes and params', function (done) {
-        shouldWarn('deprecated')
-
-        const ProfileRoute = {
-          path: '/profile'
-        }
-        UserRoute.childRoutes.push(ProfileRoute)
-
         matchRoutes(routes, createLocation('/profile'), function (error, match) {
           expect(match).toExist()
           expect(match.routes).toEqual([ RootRoute, UsersRoute, UserRoute, ProfileRoute ])

--- a/modules/isActive.js
+++ b/modules/isActive.js
@@ -53,8 +53,6 @@ function getMatchingRouteIndex(pathname, activeRoutes, activeParams) {
     const pattern = route.path || ''
 
     if (pattern.charAt(0) === '/') {
-      // This code path is deprecated, but we the deprecation warning will
-      // actually be hit from matchRoutes, not from here.
       remainingPathname = pathname
       paramNames = []
       paramValues = []

--- a/modules/matchRoutes.js
+++ b/modules/matchRoutes.js
@@ -80,13 +80,6 @@ function matchRouteDeep(
   let pattern = route.path || ''
 
   if (pattern.charAt(0) === '/') {
-    if (remainingPathname !== location.pathname) {
-      warning(
-        false,
-        'Nested routes with absolute paths are deprecated. Nest those routes under pathless routes instead. http://tiny.cc/router-decouple-ui'
-      )
-    }
-
     remainingPathname = location.pathname
     paramNames = []
     paramValues = []
@@ -98,40 +91,34 @@ function matchRouteDeep(
     paramNames = [ ...paramNames, ...matched.paramNames ]
     paramValues = [ ...paramValues, ...matched.paramValues ]
 
-    if (remainingPathname === '') {
-      if (route.path) {
-        const match = {
-          routes: [ route ],
-          params: createParams(paramNames, paramValues)
-        }
-
-        getIndexRoute(route, location, function (error, indexRoute) {
-          if (error) {
-            callback(error)
-          } else {
-            if (Array.isArray(indexRoute)) {
-              warning(
-                indexRoute.every(route => !route.path),
-                'Index routes should not have paths'
-              )
-              match.routes.push(...indexRoute)
-            } else if (indexRoute) {
-              warning(
-                !indexRoute.path,
-                'Index routes should not have paths'
-              )
-              match.routes.push(indexRoute)
-            }
-
-            callback(null, match)
-          }
-        })
-
-        return
+    if (remainingPathname === '' && route.path) {
+      const match = {
+        routes: [ route ],
+        params: createParams(paramNames, paramValues)
       }
 
-      // Re-normalize remaining path for continued match.
-      remainingPathname = '/'
+      getIndexRoute(route, location, function (error, indexRoute) {
+        if (error) {
+          callback(error)
+        } else {
+          if (Array.isArray(indexRoute)) {
+            warning(
+              indexRoute.every(route => !route.path),
+              'Index routes should not have paths'
+            )
+            match.routes.push(...indexRoute)
+          } else if (indexRoute) {
+            warning(
+              !indexRoute.path,
+              'Index routes should not have paths'
+            )
+            match.routes.push(indexRoute)
+          }
+
+          callback(null, match)
+        }
+      })
+      return
     }
   }
 


### PR DESCRIPTION
This is a feature I've really wanted to get into place since https://github.com/reactjs/react-router/issues/3172, but on further thought it doesn't make sense to include in the next release here.

I'll be bringing back this deprecation at some future point when I can make a better case for the reasons for doing so, around the possibility of async route fallthrough that will be possible once this feature is actually removed in the next release.
